### PR TITLE
load_confounds_kwargs

### DIFF
--- a/nixtract/cli/base.py
+++ b/nixtract/cli/base.py
@@ -262,7 +262,6 @@ def _make_regressor_file(outputs, out_dir):
 
     if len(reg_dict) != 0:
         # check if all extractors used load_confounds
-        print([x[1]._load_confounds for x in outputs])
         if all([x[1]._load_confounds for x in outputs]):
             reg_file = os.path.join(out_dir, 'nixtract_data',
                                     'load_confound_regressors.json')

--- a/nixtract/cli/cifti.py
+++ b/nixtract/cli/cifti.py
@@ -97,6 +97,8 @@ def extract_cifti(input_file, roi_file, regressor_file, params):
     extractor.extract()
     out = os.path.join(params['out_dir'], replace_file_ext(input_file))
     extractor.save(out, params['n_decimals'])
+
+    return out, extractor
     
 
 def main():

--- a/nixtract/cli/cifti.py
+++ b/nixtract/cli/cifti.py
@@ -88,7 +88,8 @@ def extract_cifti(input_file, roi_file, regressor_file, params):
         detrend=params['detrend']
     )
     if regressor_file is not None:
-        extractor.set_regressors(regressor_file, params['regressors'])
+        extractor.set_regressors(regressor_file, params['regressors'], 
+                                 params["load_confound_kwargs"])
 
     if (params['discard_scans'] is not None) and (params['discard_scans'] > 0):
         extractor.discard_scans(params['discard_scans'])

--- a/nixtract/cli/gifti.py
+++ b/nixtract/cli/gifti.py
@@ -169,7 +169,8 @@ def extract_gifti(input_files, roi_file, regressor_file, params):
         detrend=params['detrend']
     )
     if regressor_file is not None:
-        extractor.set_regressors(regressor_file, params['regressors'])
+        extractor.set_regressors(regressor_file, params['regressors'], 
+                                 params["load_confound_kwargs"])
 
     if (params['discard_scans'] is not None) and (params['discard_scans'] > 0):
         extractor.discard_scans(params['discard_scans'])

--- a/nixtract/cli/gifti.py
+++ b/nixtract/cli/gifti.py
@@ -177,6 +177,8 @@ def extract_gifti(input_files, roi_file, regressor_file, params):
     
     extractor.extract()
     extractor.save(out, params['n_decimals'])
+
+    return out, extractor
     
 
 def main():

--- a/nixtract/cli/nifti.py
+++ b/nixtract/cli/nifti.py
@@ -225,7 +225,8 @@ def extract_nifti(input_file, roi_file, regressor_file, params):
         smoothing_fwhm=params['smoothing_fwhm']
     )
     if regressor_file is not None:
-        extractor.set_regressors(regressor_file, params['regressors'])
+        extractor.set_regressors(regressor_file, params['regressors'], 
+                                 params["load_confound_kwargs"])
 
     if (params['discard_scans'] is not None) and (params['discard_scans'] > 0):
         extractor.discard_scans(params['discard_scans'])

--- a/nixtract/cli/nifti.py
+++ b/nixtract/cli/nifti.py
@@ -235,6 +235,7 @@ def extract_nifti(input_file, roi_file, regressor_file, params):
     out = os.path.join(params['out_dir'], replace_file_ext(input_file))
     extractor.save(out, params['n_decimals'])
 
+    return out, extractor
 
 def main():
     params = vars(_cli_parser())

--- a/nixtract/extractors/base_extractor.py
+++ b/nixtract/extractors/base_extractor.py
@@ -112,19 +112,23 @@ class BaseExtractor(object):
             regs = pd.read_table(regressor_file)
             names = regs.columns
             regs = regs.values
+            self._load_confounds = False
         
         elif len(regressors) == 1 and (regressors[0] in strategies):
             regs, names = _load_predefined_strategy(regressors[0], 
                                                     regressor_file, 
                                                     load_confounds_kwargs)
-        
+            self._load_confounds = True
+
         elif set(regressors) <= set(flexible_strategies):
             regs, names = _load_flexible_strategy(regressors, regressor_file, 
                                                   load_confounds_kwargs)
-        
+            self._load_confounds = True
+
         elif all([x not in strategies + flexible_strategies 
                   for x in regressors]):
             regs, names = _load_regressor_names(regressors, regressor_file)
+            self._load_confounds = False
         
         else:
             raise ValueError('Invalid regressors. Regressors must be a list '

--- a/nixtract/extractors/base_extractor.py
+++ b/nixtract/extractors/base_extractor.py
@@ -38,9 +38,42 @@ def _load_from_strategy(denoiser, fname):
         raise ValueError(error_msg) from e
 
 
+def _load_predefined_strategy(regressors, regressor_file, kwargs=None):
+    """Read a pre-defined strategy from load_confounds"""
+    if kwargs is not None:
+        cmd = 'load_confounds.{}(**kwargs)'.format(regressors)
+    else:
+        cmd = 'load_confounds.{}()'.format(regressors)
+    
+    denoiser = eval(cmd)
+    return _load_from_strategy(denoiser, regressor_file)
+
+
+def _load_flexible_strategy(regressors, regressor_file, kwargs=None):
+    """Load a flexible strategy from load_confounds"""
+    if kwargs is not None:
+        if "strategy" in kwargs:
+            kwargs.pop('strategy')
+        denoiser = load_confounds.Confounds(strategy=regressors, **kwargs)
+    else:
+        denoiser = load_confounds.Confounds(strategy=regressors)
+    return _load_from_strategy(denoiser, regressor_file)
+
+
+def _load_regressor_names(regressors, regressor_file):
+    """Load a list of regressor names"""
+    try:
+        regs = pd.read_table(regressor_file, usecols=regressors)
+        return regs.values, regs.columns
+    except ValueError as e:
+        msg = 'Not all regressors are found in regressor file'
+        raise ValueError(msg) from e
+
+
 class BaseExtractor(object):
 
-    def set_regressors(self, regressor_file, regressors=None):
+    def set_regressors(self, regressor_file, regressors=None, 
+                       load_confounds_kwargs=None):
         """Set regressors to be used with extraction
 
         NaN imputation is done by default because nilearn.signal.clean will 
@@ -65,37 +98,34 @@ class BaseExtractor(object):
         ValueError
             Regressors is not a list or a str
         """
-
-        # specific strategies for load_confounds
+        # strategy options in load confounds
         strategies = ['Params2', 'Params6', 'Params9', 'Params24', 'Params36', 
                       'AnatCompCor', 'TempCompCor'] 
         flexible_strategies = ['motion', 'high_pass', 'wm_csf', 'compcor', 
                                'global']
 
+        if isinstance(regressors, str):
+            regressors = [regressors]
+
+        # load regressors based on regressors provided
         if regressors is None:
-            # use all regressors from file
             regs = pd.read_table(regressor_file)
             names = regs.columns
             regs = regs.values
+        
         elif len(regressors) == 1 and (regressors[0] in strategies):
-            # predefined strategy
-            denoiser = eval('load_confounds.{}()'.format(regressors[0]))
-            regs, names = _load_from_strategy(denoiser, regressor_file)
+            regs, names = _load_predefined_strategy(regressors[0], 
+                                                    regressor_file, 
+                                                    load_confounds_kwargs)
+        
         elif set(regressors) <= set(flexible_strategies):
-            # flexible strategy
-            denoiser = load_confounds.Confounds(strategy=regressors, 
-                                                demean=False)
-            regs, names = _load_from_strategy(denoiser, regressor_file)
+            regs, names = _load_flexible_strategy(regressors, regressor_file, 
+                                                  load_confounds_kwargs)
+        
         elif all([x not in strategies + flexible_strategies 
                   for x in regressors]):
-            # list of regressor names
-            try:
-                regs = pd.read_table(regressor_file, usecols=regressors)
-                names = regs.columns
-                regs = regs.values
-            except ValueError as e:
-                msg = 'Not all regressors are found in regressor file'
-                raise ValueError(msg) from e
+            regs, names = _load_regressor_names(regressors, regressor_file)
+        
         else:
             raise ValueError('Invalid regressors. Regressors must be a list '
                              'of column names that appear in regressor_files, '

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'natsort>=7.1.1',
         'scipy>=1.5.0',
         'scikit-learn>=0.24.1',
-        'load_confounds'
+        'load_confounds>=0.6.5'
     ],
     tests_require=test_deps,
     extras_require=extras,


### PR DESCRIPTION
Addresses #13. 

Can include keyword arguments for `load_confounds.Confounds` or any of the child-class strategies. CLI input is safely handled via `ast`. Works locally in CLI and with config 